### PR TITLE
Expand the salt field for the nonce

### DIFF
--- a/django_openid/models.py
+++ b/django_openid/models.py
@@ -9,7 +9,7 @@ import time, base64
 class Nonce(models.Model):
     server_url = models.CharField(max_length=255)
     timestamp = models.IntegerField()
-    salt = models.CharField(max_length=40)
+    salt = models.CharField(max_length=128)
     
     def __unicode__(self):
         return u"Nonce: %s for %s" % (self.salt, self.server_url)


### PR DESCRIPTION
This should fix the problem reported by someone using the id.koumbit.net
OpenID provider. The size of the salt needs to be larger to accomodate that
provider.
